### PR TITLE
feat(context): allow global handler context

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ Check [examples](./examples) for expanded samples.
 
 ### Wrap Surrogate Options
 
-| Option       | Type    | Default Value | Description                                 |
-| ------------ | ------- | :-----------: | ------------------------------------------- |
-| useSingleton | boolean |     true      | Informs Surrogate to operate as a Singleton |
+| Option        | Type    | Default Value | Description                                                                                 |
+| ------------- | ------- | :-----------: | ------------------------------------------------------------------------------------------- |
+| useSingleton? | boolean |     true      | Informs Surrogate to operate as a Singleton                                                 |
+| useContext?   | any     |       T       | The context in which to call surrogate handlers. Handler specific contexts take precedence. |
 
 ### Surrogate Methods
 
@@ -70,11 +71,11 @@ SurrogateHandler is any function that accepts a `NextHandler` object which can b
 | surrogate    | Surrogate | Provides handler access to surrogate wrapped instance.   |
 | next         | INext     | Object that provides flow control capabilities           |
 
-| Method   | Member Of | Parameters                            | Default Value | Description                                                                                  |
-| -------- | :-------: | ------------------------------------- | ------------- | -------------------------------------------------------------------------------------------- |
-| skip     |   INext   | (skipAmount?: number)                 | 1             | Method that will skip the next 'skipAmount' handlers                                         |
-| skipWith |   INext   | (skipAmount?: number, ...args: any[]) | 1             | Same as `skip` but will accept any number of arguments, passing to the next executed handler |
-| next     |   INext   | (nextOptions?: NextOptions)           | n/a           | Calling next may advance to the next hook.                                                   |
+| Method   | Member Of | Parameters                           | Default Value | Description                                                                                  |
+| -------- | :-------: | ------------------------------------ | ------------- | -------------------------------------------------------------------------------------------- |
+| skip     |   INext   | (skipAmount?: number)                | 1             | Method that will skip the next 'skipAmount' handlers                                         |
+| skipWith |   INext   | (skipAmount: number, ...args: any[]) | 1             | Same as `skip` but will accept any number of arguments, passing to the next executed handler |
+| next     |   INext   | (nextOptions?: NextOptions)          | n/a           | Calling next may advance to the next hook.                                                   |
 
 #### Next Options
 

--- a/src/containers/base.ts
+++ b/src/containers/base.ts
@@ -1,28 +1,12 @@
+import { SurrogateHandler } from '../interfaces';
+import { OptionsHandler } from '../options';
 import { IContainer } from './interfaces';
 import { WhichMethod } from '../which';
-import {
-  MethodWrapper,
-  SurrogateContext,
-  SurrogateHandler,
-  SurrogateHandlerOptions,
-} from '../interfaces';
-
-const defaultMethodOptions: Required<SurrogateHandlerOptions<any>> = {
-  useNext: true,
-  runConditions: [],
-  ignoreErrors: false,
-  wrapper: MethodWrapper.Sync,
-  useContext: SurrogateContext.Instance,
-};
 
 export abstract class BaseContainer<T extends object> implements IContainer<T> {
-  public options: SurrogateHandlerOptions<T>;
-
   constructor(
     public handler: SurrogateHandler<T> | Function,
     public type: WhichMethod,
-    options: SurrogateHandlerOptions<T> = {},
-  ) {
-    this.options = { ...defaultMethodOptions, ...options };
-  }
+    public options: OptionsHandler<T> = new OptionsHandler(),
+  ) {}
 }

--- a/src/containers/handler.ts
+++ b/src/containers/handler.ts
@@ -1,4 +1,5 @@
-import { SurrogateHandler, SurrogateHandlerOptions } from '../interfaces';
+import { SurrogateHandler } from '../interfaces';
+import { OptionsHandler } from '../options';
 import { BaseContainer } from './base';
 import { Which } from '../which';
 
@@ -6,7 +7,7 @@ export class HandlerContainer<T extends object> extends BaseContainer<T> {
   constructor(
     public handler: SurrogateHandler<T>,
     public type: Which,
-    options: SurrogateHandlerOptions<T>,
+    options: OptionsHandler<T>,
   ) {
     super(handler, type, options);
   }

--- a/src/containers/interfaces/index.ts
+++ b/src/containers/interfaces/index.ts
@@ -1,13 +1,14 @@
-import { SurrogateHandlerOptions, SurrogateHandler } from '../../interfaces';
 import { NextNode, ContextController } from '../../next';
+import { SurrogateHandler } from '../../interfaces';
 import { WhichMethod, Which } from '../../which';
+import { OptionsHandler } from '../../options';
 import { HandlerContainer } from '../handler';
 import { SurrogateProxy } from '../../proxy';
 import { Context } from '../../context';
 
 export interface IContainer<T extends object> {
   type: WhichMethod;
-  options: SurrogateHandlerOptions<T>;
+  options: OptionsHandler<T>;
   handler: SurrogateHandler<T> | Function;
 }
 

--- a/src/containers/method.ts
+++ b/src/containers/method.ts
@@ -1,8 +1,13 @@
+import { OptionsHandler } from '../options';
 import { BaseContainer } from './base';
 import { METHOD } from '../which';
 
 export class MethodContainer<T extends object> extends BaseContainer<T> {
-  constructor(public handler: Function, public originalArgs: any[]) {
-    super(handler, METHOD);
+  constructor(
+    public handler: Function,
+    public originalArgs: any[],
+    options: OptionsHandler<T>,
+  ) {
+    super(handler, METHOD, options);
   }
 }

--- a/src/interfaces/handlerOptions.ts
+++ b/src/interfaces/handlerOptions.ts
@@ -4,6 +4,8 @@ import { INext } from '../next';
 export type SurrogateContexts = 'instance' | 'surrogate';
 export type MethodWrappers = 'sync' | 'async';
 
+export type Contexts = SurrogateContexts | typeof Object | typeof Function | Object;
+
 export enum SurrogateContext {
   Instance = 'instance',
   Surrogate = 'surrogate',
@@ -69,7 +71,7 @@ export interface SurrogateHandlerOptions<T extends object> {
    *
    * @default instance
    */
-  useContext?: SurrogateContexts | typeof Object | typeof Function | Object;
+  useContext?: Contexts;
 
   /**
    * @description Specifies the method context wrapper to utilize

--- a/src/interfaces/surrogateOptions.ts
+++ b/src/interfaces/surrogateOptions.ts
@@ -1,10 +1,12 @@
+import { Contexts } from './handlerOptions';
+
 /**
  * Surrogate Options
  *
  * @export
  * @interface SurrogateOptions
  */
-export interface SurrogateOptions {
+export interface SurrogateOptions extends SurrogateGlobalOptions {
   /**
    * @description Instructs Surrogate to operate as a Singleton
    * @default true
@@ -12,4 +14,14 @@ export interface SurrogateOptions {
    * @memberof SurrogateOptions
    */
   useSingleton?: boolean;
+}
+
+export interface SurrogateGlobalOptions {
+  /**
+   * @description Defines a global context for use with all handlers and methods. Method defined contexts take precedence.
+   * @default instance
+   * @type {Contexts}
+   * @memberof SurrogateOptions
+   */
+  useContext?: Contexts;
 }

--- a/src/manager/index.ts
+++ b/src/manager/index.ts
@@ -1,8 +1,14 @@
-import { WhichContainers, SurrogateHandler, SurrogateHandlerOptions } from '../interfaces';
 import { HandlerContainer } from '../containers';
 import { wrapDefaults } from '@status/defaults';
 import { PRE, POST, Which } from '../which';
+import { OptionsHandler } from '../options';
 import { asArray } from '@jfrazx/asarray';
+import {
+  WhichContainers,
+  SurrogateHandler,
+  SurrogateGlobalOptions,
+  SurrogateHandlerOptions,
+} from '../interfaces';
 
 export interface EventMap<T extends object> {
   [event: string]: WhichContainers<T>;
@@ -17,6 +23,8 @@ export class EventManager<T extends object = any> {
     setUndefined: true,
     shallowCopy: false,
   });
+
+  constructor(private globalOptions: SurrogateGlobalOptions) {}
 
   getEventHandlers(event: string): WhichContainers<T> {
     return this.events[event];
@@ -54,7 +62,14 @@ export class EventManager<T extends object = any> {
     options: SurrogateHandlerOptions<T> = {},
   ): EventManager<T> {
     const currentContainers: HandlerContainer<T>[] = this.getEventHandlersFor(event, type);
-    const containers = handlers.map((handler) => new HandlerContainer(handler, type, options));
+    const containers = handlers.map(
+      (handler) =>
+        new HandlerContainer(
+          handler,
+          type,
+          new OptionsHandler({ handler: options, global: this.globalOptions }),
+        ),
+    );
     const allContainers = [...currentContainers, ...containers];
 
     this.setEventHandlersFor(event, type, allContainers);

--- a/src/next/nodes/next.ts
+++ b/src/next/nodes/next.ts
@@ -22,7 +22,7 @@ export class Next<T extends object> extends BaseNext<T> implements INext {
     this.nextNode = Next.for(proxy, context, executionContext, iterator, hookType);
   }
 
-  skipWith(times = 1, ...args: any[]): void {
+  skipWith(times: number, ...args: any[]): void {
     if (times > 0) {
       this.controller.setNext(this.nextNode);
 

--- a/src/next/nodes/preMethodNext.ts
+++ b/src/next/nodes/preMethodNext.ts
@@ -26,7 +26,7 @@ export class PreMethodNext<T extends object> extends FinalNext<T> implements INe
       context,
       controller,
       generator,
-      new MethodContainer(context.original, args),
+      new MethodContainer(context.original, args, container.options),
       hookType,
     );
   }
@@ -53,6 +53,6 @@ export class PreMethodNext<T extends object> extends FinalNext<T> implements INe
     const { options } = container;
     const preOptions = this.prevNode?.container.options ?? {};
 
-    container.options = { ...options, ...preOptions };
+    container.options = options.replace(preOptions);
   }
 }

--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -1,0 +1,42 @@
+import { SurrogateHandlerOptions, SurrogateGlobalOptions } from '../interfaces';
+import { MethodWrapper, SurrogateContext } from '../interfaces/handlerOptions';
+
+interface GlobalHandlerOptions<T extends object> {
+  handler?: SurrogateHandlerOptions<T>;
+  global?: SurrogateGlobalOptions;
+}
+
+const defaultMethodOptions: Required<SurrogateHandlerOptions<any>> = {
+  useNext: true,
+  runConditions: [],
+  ignoreErrors: false,
+  wrapper: MethodWrapper.Sync,
+  useContext: SurrogateContext.Instance,
+};
+
+export interface OptionsHandler<T extends object>
+  extends Required<SurrogateHandlerOptions<T>> {}
+
+export class OptionsHandler<T extends object> {
+  constructor(protected combinedOptions: GlobalHandlerOptions<T> = {}) {
+    const options = this.mergeOptions(combinedOptions);
+
+    Object.entries(options).forEach(([key, value]) => {
+      Object.defineProperty(this, key, {
+        enumerable: true,
+        value,
+      });
+    });
+  }
+
+  private mergeOptions({
+    handler = {},
+    global = {},
+  }: GlobalHandlerOptions<T>): Required<SurrogateHandlerOptions<T>> {
+    return { ...defaultMethodOptions, ...global, ...handler };
+  }
+
+  replace(handlerOptions: SurrogateHandlerOptions<T>): OptionsHandler<T> {
+    return new OptionsHandler({ handler: { ...this, ...handlerOptions } });
+  }
+}

--- a/test/next.spec.ts
+++ b/test/next.spec.ts
@@ -40,52 +40,6 @@ describe('Next', () => {
       sinon.assert.calledOnce(log);
     });
 
-    it('should call handlers with the proxied (unwrapped) object as context', () => {
-      network
-        .getSurrogate()
-        .registerPreHook('connect', function (this: Network, { next }: NextHandler<Network>) {
-          expect(this).to.be.instanceOf(Network);
-          expect(this).to.not.equal(network);
-          next.next();
-        });
-
-      network.connect();
-    });
-
-    it('should call handlers with the surrogate (wrapped) object as context', () => {
-      network.getSurrogate().registerPreHook(
-        'connect',
-        function (this: Network, { next }: NextHandler<Network>) {
-          expect(this).to.be.instanceOf(Network);
-          expect(this).to.equal(network);
-          next.next();
-        },
-        {
-          useContext: SurrogateContext.Surrogate,
-        },
-      );
-
-      network.connect();
-    });
-
-    it('should call handlers with the passed options object as context', () => {
-      const otherNetwork = new Network();
-
-      network.getSurrogate().registerPreHook(
-        'connect',
-        function (this: Network, { next }: NextHandler<Network>) {
-          expect(this).to.be.instanceOf(Network);
-          expect(this).to.equal(otherNetwork);
-          next.next();
-        },
-        {
-          useContext: otherNetwork,
-        },
-      );
-
-      network.connect();
-    });
-
     it('should pass arguments from one handler to the next', () => {
       network.getSurrogate().registerPreHook('connect', [
         ({ next }: NextHandler<Network>) => next.next({ using: [1, 2, 3] }),
@@ -156,6 +110,114 @@ describe('Next', () => {
       const name = network.checkServer(serverName);
 
       expect(name).to.equal(serverName);
+    });
+  });
+
+  describe('HandlerContext', () => {
+    it('should call handlers with the proxied (unwrapped) object as context', () => {
+      network
+        .getSurrogate()
+        .registerPreHook('connect', function (this: Network, { next }: NextHandler<Network>) {
+          expect(this).to.be.instanceOf(Network);
+          expect(this).to.not.equal(network);
+          next.next();
+        });
+
+      network.connect();
+    });
+
+    it('should call handlers with the surrogate (wrapped) object as context', () => {
+      network.getSurrogate().registerPreHook(
+        'connect',
+        function (this: Network, { next }: NextHandler<Network>) {
+          expect(this).to.be.instanceOf(Network);
+          expect(this).to.equal(network);
+          next.next();
+        },
+        {
+          useContext: SurrogateContext.Surrogate,
+        },
+      );
+
+      network.connect();
+    });
+
+    it('should call handlers with the passed options object as context', () => {
+      const otherNetwork = new Network();
+
+      network.getSurrogate().registerPreHook(
+        'connect',
+        function (this: Network, { next }: NextHandler<Network>) {
+          expect(this).to.be.instanceOf(Network);
+          expect(this).to.equal(otherNetwork);
+          next.next();
+        },
+        {
+          useContext: otherNetwork,
+        },
+      );
+
+      network.connect();
+    });
+
+    it('should run with a global context', () => {
+      class GlobalContextTest {
+        method(instance: GlobalContextTest) {
+          expect(
+            this,
+            'GlobalContextTest method "this" is not equal to passed instance',
+          ).to.equal(instance);
+        }
+      }
+
+      const instance = new GlobalContextTest();
+
+      const globalContextTest = wrapSurrogate(instance, {
+        useContext: 'surrogate',
+      });
+
+      globalContextTest
+        .getSurrogate()
+        .registerPreHook('method', function (this: GlobalContextTest, { next, surrogate }) {
+          expect(
+            surrogate,
+            'GlobalContextTest NextHandler Surrogate is not equal to this',
+          ).to.equal(this);
+
+          next.next();
+        });
+
+      globalContextTest.method(instance);
+    });
+
+    it('should method specific context should override global context', () => {
+      class GlobalContextTest {
+        method(instance: GlobalContextTest) {
+          expect(
+            this,
+            'GlobalContextTest method "this" is not equal to passed instance',
+          ).to.equal(instance);
+        }
+      }
+
+      const instance = new GlobalContextTest();
+
+      const globalContextTest = wrapSurrogate(instance, {
+        useContext: 'instance',
+      });
+
+      globalContextTest
+        .getSurrogate()
+        .registerPreHook('method', function (this: GlobalContextTest, { next, surrogate }) {
+          expect(
+            surrogate,
+            'GlobalContextTest NextHandler Surrogate is equal to this',
+          ).not.to.equal(this);
+
+          next.next();
+        });
+
+      globalContextTest.method(instance);
     });
   });
 


### PR DESCRIPTION
Ability to define a global handler context. Handler specific contexts take precedence. 

When wrapping an object surrogate now determines if it is already wrapped. If so the passed object is returned. 