### PR TITLE
feat(context): allow surrogate to maintain context on unhooked methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ Check [examples](./examples) for expanded samples.
 
 ### SurrogateOptions
 
-| Option        | Type    | Default Value | Description                                                                                         |
-| ------------- | ------- | :-----------: | --------------------------------------------------------------------------------------------------- |
-| useSingleton? | boolean |     true      | Informs Surrogate to operate as a Singleton                                                         |
-| useContext?   | any     |       T       | The context in which to call surrogate handlers. Handler specific contexts take precedence.         |
-| provide       | any     |     null      | User provided content to pass to handlers and conditionals. Handler specific values take precedence |
+| Option           | Type                          | Default Value | Description                                                                                         |
+| ---------------- | ----------------------------- | :-----------: | --------------------------------------------------------------------------------------------------- |
+| useSingleton?    | boolean                       |     true      | Informs Surrogate to operate as a Singleton                                                         |
+| useContext?      | any                           |       T       | The context in which to call surrogate handlers. Handler specific contexts take precedence.         |
+| provide?         | any                           |     null      | User provided content to pass to handlers and conditionals. Handler specific values take precedence |
+| maintainContext? | boolean \| string \| string[] |     false     | Maintain context for methods without hooks. Can be a method name or array of method names           |
 
 ### SurrogateMethods
 
@@ -157,7 +158,7 @@ A RunCondition is a function that receives `RunConditionParameters`, which inclu
 
 | Property          | Member Of           | Type    | Description                                |
 | ----------------- | ------------------- | ------- | ------------------------------------------ |
-| bailWith()        | RunOnBailParameters | any     | Function that accepts a value ti bail with |
+| bailWith()        | RunOnBailParameters | any     | Function that accepts a value to bail with |
 | recoverFromBail() | RunOnBailParameters | boolean | Function to recover from a bailing handler |
 
 ---
@@ -187,7 +188,7 @@ import { SurrogateDelegate } from 'surrogate';
 class Guitar {}
 ```
 
-If you wish to use `Surrogate` [methods](#-SurrogateMethods) on your class instance you must extend `SurrogateMethods` interface.
+If you wish to use `Surrogate` [methods](#-SurrogateMethods) inside this instance of your class you must extend `SurrogateMethods` interface.
 
 ```typescript
 import { SurrogateDelegate, SurrogateMethods } from 'surrogate';

--- a/src/decorate/nextDecorators.ts
+++ b/src/decorate/nextDecorators.ts
@@ -19,10 +19,11 @@ type PropertyDecorator<T extends object> = (
  * @param {(NextForOptions<T> | NextForOptions<T>[])} nextOptions
  * @returns {PropertyDecorator<T>}
  */
-export const NextFor = <T extends object>(
-  nextOptions: NextForOptions<T> | NextForOptions<T>[],
-): PropertyDecorator<T> => {
-  return (target: T, event: string): void => {
+export const NextFor =
+  <T extends object>(
+    nextOptions: NextForOptions<T> | NextForOptions<T>[],
+  ): PropertyDecorator<T> =>
+  (target: T, event: string): void =>
     asArray(nextOptions).forEach((nextOption) => {
       const { type, action, options } = nextOption;
       const which: Which[] = determineWhich(type);
@@ -30,15 +31,13 @@ export const NextFor = <T extends object>(
 
       which.forEach((type) =>
         actions.forEach((action) =>
-          manageDecorator(type, {
+          manageDecorator<T>(type, {
             handler: event,
             options,
           })(target, action),
         ),
       );
     });
-  };
-};
 
 /**
  * Designate decorated methods as async pre hooks.
@@ -95,11 +94,13 @@ const nextAsyncHelper = <T extends object>(
 ): PropertyDecorator<T> => {
   return (target: T, event: string, descriptor: PropertyDescriptor): void =>
     asArray(nextOptions).forEach(({ action, options }) =>
-      NextFor({
-        action,
+      nextHelper<T>(
+        {
+          action,
+          options: { ...options, wrapper: MethodWrapper.Async },
+        },
         type,
-        options: { ...options, wrapper: MethodWrapper.Async },
-      })(target, event, descriptor),
+      )(target, event, descriptor),
     );
 };
 
@@ -148,7 +149,7 @@ export const NextPreAndPost = <T extends object>(
   const which: Which[] = [PRE, POST];
 
   return (target: T, event: string, descriptor: PropertyDescriptor): void => {
-    which.forEach((type) => nextHelper(nextOptions, type)(target, event, descriptor));
+    which.forEach((type) => nextHelper<T>(nextOptions, type)(target, event, descriptor));
   };
 };
 
@@ -158,7 +159,7 @@ const nextHelper = <T extends object>(
 ): PropertyDecorator<T> => {
   return (target: T, event: string, descriptor: PropertyDescriptor): void =>
     asArray(hookOptions).forEach(({ action, options }) =>
-      NextFor({
+      NextFor<T>({
         action,
         type,
         options,

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,4 +1,6 @@
 export const isNull = (value: unknown): value is null => value === null;
+export const isBool = (value: unknown): value is boolean => isType(value, 'boolean');
+export const isString = (value: unknown): value is string => isType(value, 'string');
 export const isFunction = (value: unknown): value is Function => isType(value, 'function');
 export const isUndefined = (value: unknown): value is undefined => isType(value, 'undefined');
 export const isObject = (value: unknown): value is object =>

--- a/src/identifier/index.ts
+++ b/src/identifier/index.ts
@@ -1,0 +1,49 @@
+import { isFunction } from '../helpers';
+
+export class MethodIdentifier<T extends object> {
+  constructor(private instance: T) {}
+
+  doesNotIncludeEvent(event: string, methods: string[]): boolean {
+    const properties = this.instancePropertyNames();
+
+    return properties.includes(event) ? !this.includesEvent(event, methods) : true;
+  }
+
+  private includesEvent(event: string, methods: string[]): boolean {
+    return methods
+      .filter((v) => v)
+      .map((method) => new RegExp(method))
+      .some((regex) => regex.test(event));
+  }
+
+  getApplicableMethods(event: string, methods: string[]): string[] {
+    const methodTest = new RegExp(event);
+
+    return methods.includes(event)
+      ? [event]
+      : methods.filter((method) => methodTest.test(method));
+  }
+
+  instancePropertyNames() {
+    const properties = this.getPropertyNames();
+
+    return properties
+      .filter((prop) => prop !== 'constructor')
+      .filter((name) => isFunction(Reflect.get(this.instance, name)));
+  }
+
+  private getPropertyNames(): string[] {
+    const objectProto = Object.getPrototypeOf({});
+    const props: string[][] = [];
+    let current = this.instance;
+
+    do {
+      props.push(Object.getOwnPropertyNames(current));
+    } while (
+      Object.getPrototypeOf(current) !== objectProto &&
+      (current = Object.getPrototypeOf(current))
+    );
+
+    return [...new Set(props.flatMap((p) => p)).values()];
+  }
+}

--- a/src/interfaces/surrogateOptions.ts
+++ b/src/interfaces/surrogateOptions.ts
@@ -15,6 +15,14 @@ export interface SurrogateOptions extends SurrogateGlobalOptions {
    * @memberof SurrogateOptions
    */
   useSingleton?: boolean;
+
+  /**
+   * @description Will force Surrogate to run specified methods with or without hooks.
+   * @default false
+   * @Type {boolean|string|string[]}
+   * @memberof SurrogateOptions
+   */
+  maintainContext?: boolean | string | string[];
 }
 
 export interface SurrogateGlobalOptions {

--- a/src/manager/index.ts
+++ b/src/manager/index.ts
@@ -6,10 +6,10 @@ import { asArray } from '@jfrazx/asarray';
 import {
   EventMap,
   WhichContainers,
+  SurrogateOptions,
   SurrogateHandlers,
   SurrogateEventManager,
   SurrogateHandlerTypes,
-  SurrogateGlobalOptions,
   SurrogateHandlerOptions,
 } from '../interfaces';
 
@@ -23,7 +23,7 @@ export class EventManager<T extends object = any> implements SurrogateEventManag
     shallowCopy: false,
   });
 
-  constructor(private globalOptions: SurrogateGlobalOptions = {}) {}
+  constructor(public globalOptions: SurrogateOptions = {}) {}
 
   getEventMap() {
     return this.events;

--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -1,30 +1,7 @@
-import {
-  MethodWrapper,
-  SurrogateContext,
-  SurrogateGlobalOptions,
-  SurrogateHandlerOptions,
-} from '../interfaces';
+import { CombinedOptions, GlobalHandlerOptions } from './interfaces';
+import { defaultGlobalOptions, defaultMethodOptions } from './lib';
 
-interface GlobalHandlerOptions<T extends object> {
-  handler?: SurrogateHandlerOptions<T>;
-  global?: SurrogateGlobalOptions;
-}
-
-const defaultMethodOptions: Required<SurrogateHandlerOptions<any>> = {
-  priority: 0,
-  noArgs: false,
-  useNext: true,
-  provide: null,
-  runOnBail: [],
-  runOnError: [],
-  runConditions: [],
-  ignoreErrors: false,
-  wrapper: MethodWrapper.Sync,
-  useContext: SurrogateContext.Instance,
-};
-
-export interface OptionsHandler<T extends object>
-  extends Required<SurrogateHandlerOptions<T>> {}
+export interface OptionsHandler<T extends object> extends CombinedOptions<T> {}
 
 export class OptionsHandler<T extends object> {
   constructor(protected combinedOptions: GlobalHandlerOptions<T> = {}) {
@@ -41,7 +18,7 @@ export class OptionsHandler<T extends object> {
   private mergeOptions({
     handler = {},
     global = {},
-  }: GlobalHandlerOptions<T>): Required<SurrogateHandlerOptions<T>> {
-    return { ...defaultMethodOptions, ...global, ...handler };
+  }: GlobalHandlerOptions<T>): CombinedOptions<T> {
+    return { ...defaultMethodOptions, ...defaultGlobalOptions, ...global, ...handler };
   }
 }

--- a/src/options/interfaces/index.ts
+++ b/src/options/interfaces/index.ts
@@ -1,0 +1,9 @@
+import { SurrogateOptions, SurrogateHandlerOptions } from '../../interfaces';
+
+export interface GlobalHandlerOptions<T extends object> {
+  handler?: SurrogateHandlerOptions<T>;
+  global?: SurrogateOptions;
+}
+
+export type CombinedOptions<T extends object> = Required<SurrogateHandlerOptions<T>> &
+  Required<Omit<SurrogateOptions, 'useSingleton'>>;

--- a/src/options/lib/index.ts
+++ b/src/options/lib/index.ts
@@ -1,0 +1,25 @@
+import {
+  MethodWrapper,
+  SurrogateContext,
+  SurrogateOptions,
+  SurrogateHandlerOptions,
+} from '../../interfaces';
+
+export const defaultMethodOptions: Required<SurrogateHandlerOptions<any>> = {
+  priority: 0,
+  noArgs: false,
+  useNext: true,
+  provide: null,
+  runOnBail: [],
+  runOnError: [],
+  runConditions: [],
+  ignoreErrors: false,
+  wrapper: MethodWrapper.Sync,
+  useContext: SurrogateContext.Instance,
+};
+
+export const defaultGlobalOptions: Required<
+  Omit<Omit<SurrogateOptions, 'useSingleton'>, keyof SurrogateHandlerOptions<any>>
+> = {
+  maintainContext: false,
+};

--- a/test/context.spec.ts
+++ b/test/context.spec.ts
@@ -1,24 +1,113 @@
+import { Surrogate, wrapSurrogate } from '../src';
 import { Context } from '../src/context';
 import { Network } from './lib/network';
-import { Surrogate } from '../src';
 import { expect } from 'chai';
 
 describe('Context', () => {
-  let network: Network;
-  let context: Context<Network>;
+  describe('Class', () => {
+    let network: Network;
+    let context: Context<Network>;
 
-  beforeEach(() => {
-    network = new Network();
-    context = new Context(
-      network,
-      network as unknown as Surrogate<Network>,
-      'connect',
-      network.connect,
-      [],
-    );
+    beforeEach(() => {
+      network = new Network();
+      context = new Context(
+        network,
+        network as unknown as Surrogate<Network>,
+        'connect',
+        network.connect,
+        [],
+      );
+    });
+
+    it('should be an instance of Context', () => {
+      expect(context).to.be.instanceOf(Context);
+    });
   });
 
-  it('should be an instance of Context', () => {
-    expect(context).to.be.instanceOf(Context);
+  describe(`Maintain`, () => {
+    it(`should not maintain context when no hooks are present`, () => {
+      const network = wrapSurrogate(new Network(), {});
+      const method = network.disable;
+
+      expect(network.isEnabled).to.be.true;
+      expect(() => method()).to.throw(Error);
+
+      expect(network.isEnabled).to.be.true;
+    });
+
+    it(`should maintain context when no hooks are present`, () => {
+      const network = wrapSurrogate(new Network(), {
+        maintainContext: true,
+      });
+
+      const method = network.disable;
+
+      expect(network.isEnabled).to.be.true;
+
+      method();
+
+      expect(network.isEnabled).to.be.false;
+
+      const method2 = network.enable;
+
+      method2();
+
+      expect(network.isEnabled).to.be.true;
+    });
+
+    it(`should maintain context for a specific method`, () => {
+      const network = wrapSurrogate(new Network(), {
+        maintainContext: 'disable',
+      });
+
+      const method = network.disable;
+      const method2 = network.enable;
+
+      expect(network.isEnabled).to.be.true;
+
+      method();
+
+      expect(network.isEnabled).to.be.false;
+
+      expect(() => method2()).to.throw(TypeError);
+
+      expect(network.isEnabled).to.be.false;
+    });
+
+    it(`should maintain context for multiple specified methods`, () => {
+      const network = wrapSurrogate(new Network(), {
+        maintainContext: ['disable', 'enable'],
+      });
+
+      const method = network.disable;
+      const method2 = network.enable;
+      const method3 = network.connect;
+
+      expect(network.isEnabled).to.be.true;
+
+      method();
+
+      expect(network.isEnabled).to.be.false;
+
+      method2();
+
+      expect(network.isEnabled).to.be.true;
+
+      expect(() => method3()).to.throw(TypeError);
+    });
+
+    it(`should ignore invalid context`, () => {
+      const network = wrapSurrogate(new Network(), {
+        maintainContext: null,
+      });
+
+      const method = network.disable;
+
+      expect(network.isEnabled).to.be.true;
+
+      expect(() => method()).to.throw(TypeError);
+
+      expect(network.isEnabled).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
Specifying a method or list of methods allows Surrogate to maintain object context on the specified methods when they are not called through the object. 